### PR TITLE
Fix missing runtime deps and bootstrap plugin venv

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,6 +24,32 @@
 """
 
 
+def _bootstrap_venv():
+    """Add the plugin's self-contained virtualenv to sys.path.
+
+    GroundTruther's Python dependencies (pandas, opencv, pyqtgraph, numba, ...)
+    are installed into a ``.venv`` created alongside the plugin source with
+    ``--system-site-packages`` against the same Python QGIS uses.  This makes
+    them importable inside QGIS regardless of how QGIS was launched, without
+    relying on a profile ``startup.py``.  No-op if the venv is absent.
+    """
+    import sys
+    from pathlib import Path
+
+    plugin_dir = Path(__file__).resolve().parent
+    site = (plugin_dir / ".venv" / "lib"
+            / f"python{sys.version_info.major}.{sys.version_info.minor}"
+            / "site-packages")
+    if site.is_dir():
+        p = str(site)
+        if p not in sys.path:
+            # Append so QGIS/system packages keep priority over venv copies.
+            sys.path.append(p)
+
+
+_bootstrap_venv()
+
+
 # noinspection PyPep8Naming
 def classFactory(iface):  # pylint: disable=invalid-name
     """Load GroundTruther class from file GroundTruther.

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -32,13 +32,17 @@ plotnine
 pyproj
 simplekml
 requests
+geojson
 
 # ---- Config & templating ----
 PyYAML
-# pydantic v1 API (error_wrappers) – pin below v2
-pydantic>=1.9,<2
+# pydantic – config_model.py validates correctly under both v1 and v2;
+# configure.py imports ValidationError with a v1→v2 fallback.
+pydantic>=1.9
 starlette
 Jinja2
 
-# ---- Optional: JIT acceleration (requires LLVM toolchain on Windows) ----
-# numba
+# ---- JIT acceleration ----
+# Required: the BS Query Builder imports pip_cpu (numba) unconditionally.
+# On Windows this needs an LLVM toolchain.
+numba


### PR DESCRIPTION
Fixes plugin load failures under QGIS 4 / Python 3.14:

- **requirements.txt:** add `geojson` and `numba` — both imported unconditionally by the BS Query Builder (`pip_cpu.py`) but were missing, causing `ModuleNotFoundError` on load. Relax the pydantic pin (`config_model.py` validates under both v1 and v2).
- **`__init__.py`:** add `_bootstrap_venv()` so the plugin's self-contained `.venv` (created with `--system-site-packages` alongside the source) is appended to `sys.path` when QGIS imports the plugin — making deps like `pyqtgraph` importable regardless of how QGIS is launched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)