### PR TITLE
Hide cloud services when FastGIS isn't configured

### DIFF
--- a/groundtruther_dockwidget.py
+++ b/groundtruther_dockwidget.py
@@ -269,6 +269,9 @@ class GroundTrutherDockWidget(
         self._init_layout()                  # LayoutMixin — restore saved positions + reset action
         self._init_session()                 # SessionMixin — load session file + project-save hook
 
+        # Hide the cloud-dependent services when FastGIS isn't configured.
+        self._apply_cloud_availability()
+
         self.w.show()
 
     # ------------------------------------------------------------------ #
@@ -281,6 +284,54 @@ class GroundTrutherDockWidget(
             self.w.gisTools_logger.hide()
         else:
             self.w.gisTools.show()
+
+    # ------------------------------------------------------------------ #
+    # Cloud-service availability (FastGIS)                                 #
+    # ------------------------------------------------------------------ #
+
+    def _cloud_service_configured(self) -> bool:
+        """True when the FastGIS cloud service is configured.
+
+        Either the GRASS API endpoint + key (``Processing.*``) are both set, or
+        a roughness ``direct_url`` (the on-host GPU service) is given — in which
+        case no cloud key is needed.
+        """
+        s = self.settings or {}
+        proc = s.get("Processing", {}) or {}
+        endpoint = str(proc.get("grass_api_endpoint") or "").strip()
+        key = str(proc.get("grass_api_key") or "").strip()
+        direct = str((s.get("Roughness") or {}).get("direct_url") or "").strip()
+        return bool((endpoint and key) or direct)
+
+    def _apply_cloud_availability(self) -> None:
+        """Show/hide the cloud-dependent services based on configuration.
+
+        When FastGIS isn't configured, the GRASS tools, GRASS environment
+        settings, and the Seafloor Roughness panel are hidden + disabled (and any
+        open dock is hidden). Re-run on ``settings_saved`` so entering the key in
+        Settings (the wizard) re-enables them without a restart. The wizard /
+        main Settings dialog itself always stays available — that's where the
+        endpoint + key are entered.
+        """
+        ok = self._cloud_service_configured()
+        actions = [
+            getattr(self, "_roughness_action", None),
+            getattr(self.w, "actionGisTools", None),
+            getattr(self.w, "actiongrass_settings", None),
+        ]
+        for action in actions:
+            if action is not None:
+                action.setVisible(ok)
+                action.setEnabled(ok)
+        if not ok:
+            for dock in (getattr(self, "_roughness_dock", None),
+                         getattr(self.w, "gisTools", None),
+                         getattr(self.w, "gisTools_logger", None)):
+                if dock is not None:
+                    dock.hide()
+        QgsMessageLog.logMessage(
+            f"cloud services {'enabled' if ok else 'hidden (FastGIS not configured)'}",
+            'GroundTruther', Qgis.Info)
 
     # ------------------------------------------------------------------ #
     # Teardown                                                             #

--- a/mixins/settings_mixin.py
+++ b/mixins/settings_mixin.py
@@ -146,6 +146,11 @@ class SettingsMixin:
         """
         dialog = ConfigDialog()
         dialog.settings_saved.connect(self._apply_settings)
+        # Re-evaluate cloud-service availability after settings change (so adding
+        # the FastGIS endpoint + key re-enables GRASS / roughness without a
+        # restart). Runs after _apply_settings, which reloads self.settings.
+        if hasattr(self, "_apply_cloud_availability"):
+            dialog.settings_saved.connect(self._apply_cloud_availability)
         dialog.settings_saved.connect(self._apply_video_settings)
         # Let the query builder pick up changed data sources (soundings,
         # reference-surface GeoTIFF, …) without a plugin restart.


### PR DESCRIPTION
When the FastGIS cloud service isn't configured, hide + disable the services that depend on it, so the plugin degrades cleanly for users without an API key.

## Hidden + disabled when unconfigured
- **Seafloor Roughness** toolbar toggle + dock
- **GIS Tools** (GRASS) toolbar toggle + dock + logger
- **GRASS environment settings** action

The main **Settings (wizard)** always stays available — that's where the endpoint + key are entered.

## "Configured" =
`Processing.grass_api_endpoint` **and** `grass_api_key` are both set, **or** a `Roughness.direct_url` (the on-host GPU service, which needs no cloud key).

Re-evaluated on `settings_saved` (after `_apply_settings` reloads `self.settings`), so entering the key in Settings re-enables everything without a restart — and clearing it hides them again. State is logged to the GroundTruther log.

`config/config.yaml` stays gitignored. Unit suite: 183 passing.