### PR TITLE
Icon harmonization, theme-adaptive/live-retint icons, and image-browser robustness

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -189,6 +189,21 @@ class ConfigDialog(QDialog, AppSettings):
             "(image index, zoom, query selection, dock layout)")
         self.select_vrt_path.clicked.connect(self.set_session_path)
 
+        # On-theme tinted icons (icon-only): folder picker "…" buttons + the
+        # Save / Close actions.
+        from groundtruther.mixins.toolbar_icons import iconize
+        for name in ("select_image_path", "select_metadata_path",
+                     "select_imageannotation_path", "select_mbes_path",
+                     "select_kml_path", "select_video_path",
+                     "select_video_metadata_path", "select_vrt_path"):
+            btn = getattr(self, name, None)
+            if btn is not None:
+                iconize(btn, "folder-open.svg", "Browse…")
+        if getattr(self, "setOption", None) is not None:
+            iconize(self.setOption, "floppy-disk.svg", "Save settings")
+        if getattr(self, "quit", None) is not None:
+            iconize(self.quit, "circle-xmark.svg", "Close")
+
         # Populate fields from disk – silently, no validation dialogs
         self._populate_fields()
 
@@ -285,6 +300,8 @@ class ConfigDialog(QDialog, AppSettings):
             "this raster to the sampling shape instead of gridding the soundings.")
         button = QToolButton(); button.setText("...")
         button.clicked.connect(self.set_reference_surface_path)
+        from groundtruther.mixins.toolbar_icons import iconize
+        iconize(button, "folder-open.svg", "Browse…")
         row.addWidget(label)
         row.addWidget(self.reference_surface_path)
         row.addWidget(button)

--- a/groundtruther.py
+++ b/groundtruther.py
@@ -302,6 +302,7 @@ class GroundTruther:
 
     def initGui(self):
         """Create the menu entries and toolbar icons inside the QGIS GUI."""
+        from groundtruther.mixins.toolbar_icons import apply_icon
 
         icon_path = ':/icons/qtui/icons/epi.gif'
         self.add_action(
@@ -321,13 +322,14 @@ class GroundTruther:
         #     maptool_callback=self.print_coords)
         
 
-        image_query_icon_path = ':/icons/qtui/icons/target.png'
-        image_query_icon = QIcon(image_query_icon_path)
-        image_query_action = QAction(image_query_icon, self.tr(u'Image Browser'), self.iface.mainWindow())
+        image_query_action = QAction(self.tr(u'Image Browser'), self.iface.mainWindow())
+        image_query_action.setToolTip(self.tr(
+            u'Image Browser — click the map to seek the nearest HabCam image'))
         #
         image_query_action.triggered.connect(self.image_query)
         image_query_action.setEnabled(True)
         image_query_action.setCheckable(True)
+        apply_icon(image_query_action, "target.svg")
         #
         self.image_query_tool = QueryTool(self.iface.mapCanvas())# QueryTool(self.iface.mapCanvas())
         self.image_query_tool.setAction(image_query_action)
@@ -341,13 +343,12 @@ class GroundTruther:
         self.actions.append(image_query_action)
 
         
-        grass_query_icon_path = ':/icons/qtui/icons/gui-query.gif'
-        grass_query_icon = QIcon(grass_query_icon_path)
-        grass_query_action = QAction(grass_query_icon, self.tr(u'GRASS Query'), self.iface.mainWindow())
+        grass_query_action = QAction(self.tr(u'GRASS Query'), self.iface.mainWindow())
         #
         grass_query_action.triggered.connect(self.grass_query)
         grass_query_action.setEnabled(True)
         grass_query_action.setCheckable(True)
+        apply_icon(grass_query_action, "query.svg")
         #
         self.grass_query_tool = GRQueryTool(self.iface.mapCanvas())# QueryTool(self.iface.mapCanvas())
         self.grass_query_tool.setAction(grass_query_action)
@@ -362,13 +363,12 @@ class GroundTruther:
         self.actions.append(grass_query_action)
         
         
-        grass_cpr_icon_path = ':/icons/qtui/icons/mActionSelectRectangle.svg'
-        grass_cpr_icon = QIcon(grass_cpr_icon_path)
-        grass_cpr_action = QAction(grass_cpr_icon, self.tr(u'GRASS Computational Region'), self.iface.mainWindow())
+        grass_cpr_action = QAction(self.tr(u'GRASS Computational Region'), self.iface.mainWindow())
         #
         grass_cpr_action.triggered.connect(self.grass_cpr)
         grass_cpr_action.setEnabled(True)
         grass_cpr_action.setCheckable(True)
+        apply_icon(grass_cpr_action, "mActionSelectRectangle.svg")
         #
         self.grass_cpr_tool = GCRTool(self.iface.mapCanvas())# QueryTool(self.iface.mapCanvas())
         self.grass_cpr_tool.setAction(grass_cpr_action)

--- a/gt/image_manager.py
+++ b/gt/image_manager.py
@@ -6,11 +6,58 @@ UI feedback.
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 from scipy import spatial
+
+
+# --- on-disk image-file resolution -----------------------------------------
+# The metadata stores a bare frame name (e.g. "201503.20150619.181140656.204627").
+# Different deliveries of the same survey store the pixels under different
+# suffix/extension combinations — the mono set as "<name>.jpg", the stereo set as
+# "<name>_orig.png", etc.  Resolve by probing the common variants so one metadata
+# file drives every delivery.
+_IMAGE_VARIANTS = ("", "_orig")
+_IMAGE_EXTS = (".jpg", ".jpeg", ".png", ".tif", ".tiff")
+_PREFERRED_VARIANT: tuple | None = None   # (suffix, ext) that last matched
+
+
+def resolve_image_path(dirname, imagename) -> str | None:
+    """Return the on-disk path of *imagename* within *dirname*, or ``None``.
+
+    Probes common ``<name><suffix><ext>`` combinations (e.g. ``<name>.jpg`` and
+    ``<name>_orig.png``) so the same metadata works across mono / stereo
+    deliveries.  Remembers the matching pattern so subsequent lookups are a
+    single ``stat``.
+    """
+    global _PREFERRED_VARIANT
+    if not dirname or imagename is None or str(imagename) == "":
+        return None
+    base = os.path.join(str(dirname), str(imagename))
+    combos = []
+    if _PREFERRED_VARIANT is not None:
+        combos.append(_PREFERRED_VARIANT)
+    combos.extend((s, e) for s in _IMAGE_VARIANTS for e in _IMAGE_EXTS
+                  if (s, e) != _PREFERRED_VARIANT)
+    for suffix, ext in combos:
+        path = base + suffix + ext
+        if os.path.isfile(path):
+            _PREFERRED_VARIANT = (suffix, ext)
+            return path
+    return None
+
+
+def image_path_or_default(dirname, imagename, default_ext: str = ".jpg") -> str:
+    """:func:`resolve_image_path`, falling back to ``<name><default_ext>`` when
+    nothing is on disk — so callers always have a stable path to display/report.
+    """
+    found = resolve_image_path(dirname, imagename)
+    if found:
+        return found
+    return os.path.join(str(dirname), str(imagename) + default_ext)
 
 
 def load_metadata(parquet_path: str | Path) -> pd.DataFrame:

--- a/mixins/annotation_editor_mixin.py
+++ b/mixins/annotation_editor_mixin.py
@@ -28,10 +28,13 @@ class AnnotationEditorMixin:
         # Toolbar lives in the image browser window
         toolbar = self._image_toolbar
 
+        from groundtruther.mixins.toolbar_icons import iconize
+
         self._ann_editor_action = QtWidgets.QAction("Annotate", self._image_inner_window)
         self._ann_editor_action.setCheckable(True)
         self._ann_editor_action.setToolTip("Show/hide the annotation editor panel")
         self._ann_editor_action.toggled.connect(self._toggle_annotation_editor)
+        iconize(self._ann_editor_action, "table.svg")
         toolbar.addAction(self._ann_editor_action)
 
         toolbar.addSeparator()
@@ -41,6 +44,7 @@ class AnnotationEditorMixin:
         self._draw_ann_action.setToolTip(
             "Click and drag on the image to draw a new bounding box")
         self._draw_ann_action.toggled.connect(self._toggle_draw_mode)
+        iconize(self._draw_ann_action, "mActionSelectRectangle.svg")
         self._draw_ann_action.setVisible(False)
         toolbar.addAction(self._draw_ann_action)
 

--- a/mixins/grass_mixin.py
+++ b/mixins/grass_mixin.py
@@ -42,7 +42,14 @@ class GrassIntegrationMixin:
         self.w.actiongrass_settings.triggered.connect(self.show_grass_dialog)
 
     def show_grass_dialog(self):
-        self.grass_dialog.exec()
+        act = getattr(self.w, "actiongrass_settings", None)
+        if act is not None and act.isCheckable():
+            act.setChecked(True)            # highlight the toolbar button while open
+        try:
+            self.grass_dialog.exec()
+        finally:
+            if act is not None and act.isCheckable():
+                act.setChecked(False)
         QgsMessageLog.logMessage(
             f"GRASS dialog closed, grassenabled={self.grass_dialog.grassenabled}",
             'GroundTruther', Qgis.Info)
@@ -59,13 +66,18 @@ class GrassIntegrationMixin:
             return
         self._grass_ctx_added = True
 
+        from groundtruther.mixins.toolbar_icons import apply_icon
+
         self.action_import_raster = QAction(
             "Send to active GRASS environment")
+        apply_icon(self.action_import_raster, "grass_location.svg")
         self.action_import_raster.triggered.connect(
             self.import_active_raster_layer_to_grass)
 
         self.action_set_computational_region_from_raster = QAction(
             "Set GRASS Server Computational Region to layer extent")
+        apply_icon(self.action_set_computational_region_from_raster,
+                   "mActionSelectRectangle.svg")
         self.action_set_computational_region_from_raster.triggered.connect(
             self.set_grass_region_from_raster)
 
@@ -78,11 +90,14 @@ class GrassIntegrationMixin:
 
         self.action_import_vector = QAction(
             "Send to active GRASS environment")
+        apply_icon(self.action_import_vector, "grass_location.svg")
         self.action_import_vector.triggered.connect(
             self.import_active_vector_layer_to_grass)
 
         self.action_set_computational_region_from_vector = QAction(
             "Set GRASS Server Computational Region to layer extent")
+        apply_icon(self.action_set_computational_region_from_vector,
+                   "mActionSelectRectangle.svg")
         self.action_set_computational_region_from_vector.triggered.connect(
             self.set_grass_region_from_vector)
 

--- a/mixins/image_browser_mixin.py
+++ b/mixins/image_browser_mixin.py
@@ -478,7 +478,7 @@ class ImageBrowserMixin:
             except KeyError:
                 continue
             if col == "Imagename":
-                link = os.path.join(self.dirname, str(val) + ".jpg")
+                link = img_mgr.image_path_or_default(self.dirname, str(val))
                 w.setText(f'<a href="file://{link}">{val}</a>')
             elif col == "Annotation":
                 if isinstance(val, dict) and "Species" in val:
@@ -500,9 +500,9 @@ class ImageBrowserMixin:
         if self.imageMetadata is None:
             return
 
-        img_path = os.path.join(
+        img_path = img_mgr.image_path_or_default(
             self.dirname,
-            self.imageMetadata["Imagename"].iloc[self.imageindex] + ".jpg",
+            self.imageMetadata["Imagename"].iloc[self.imageindex],
         )
         self.imv.imageItem.axisOrder = "row-major"
         if self.w.actionImageBrowser.isChecked():
@@ -510,24 +510,43 @@ class ImageBrowserMixin:
 
         # A new frame invalidates any micro-DEM overlay from the previous one.
         self._clear_micro_dem_overlay()
-        disp = _split_stereo(_cached_imread(img_path), self._stereo_display_mode)
-        self._displayed_shape = getattr(disp, "shape", None)
-        self.imv.setImage(disp)
+        # The image referenced by the metadata may not be on disk (partial
+        # dataset, unmounted drive, corrupt file). Decode defensively: on failure
+        # warn in the status bar and carry on so the metadata panel + map marker
+        # still update for the frame — only the picture is skipped.
+        disp = None
+        try:
+            raw = _cached_imread(img_path)
+            # Reveal the Full/Left/Right toggle only when this frame is actually a
+            # side-by-side stereo pair; hide it for ordinary single-camera frames.
+            self._set_stereo_controls_visible(_is_stereo_pair(raw))
+            disp = _split_stereo(raw, self._stereo_display_mode)
+        except Exception as exc:  # noqa: BLE001 — a bad/missing frame must not crash browsing
+            self._warn_image_missing(img_path, exc)
 
-        # Annotation editor dock takes priority if open
-        ann_editor_open = (
-            hasattr(self, 'annotation_editor_dock')
-            and self.annotation_editor_dock.isVisible()
-        )
-        if ann_editor_open:
-            annotation = self.imageMetadata["Annotation"].iloc[self.imageindex]
-            imagename = self.imageMetadata["Imagename"].iloc[self.imageindex]
-            self.annotation_editor.load_image(
-                self.imageindex, imagename,
-                annotation, self.imageannotationfile)
-        elif self.w.actionAnnotation.isChecked():
-            self.add_image_annotation()
+        self._displayed_shape = getattr(disp, "shape", None)
+        self._displayed_arr = disp
+        if disp is not None:
+            self.imv.setImage(disp)
+            self._apply_auto_stretch()
+
+            # Annotation editor dock takes priority if open
+            ann_editor_open = (
+                hasattr(self, 'annotation_editor_dock')
+                and self.annotation_editor_dock.isVisible()
+            )
+            if ann_editor_open:
+                annotation = self.imageMetadata["Annotation"].iloc[self.imageindex]
+                imagename = self.imageMetadata["Imagename"].iloc[self.imageindex]
+                self.annotation_editor.load_image(
+                    self.imageindex, imagename,
+                    annotation, self.imageannotationfile)
+            elif self.w.actionAnnotation.isChecked():
+                self.add_image_annotation()
+            else:
+                self.clear_image_annotation()
         else:
+            # No image to draw annotations on.
             self.clear_image_annotation()
 
         record = self.imageMetadata.iloc[self.imageindex]
@@ -555,11 +574,26 @@ class ImageBrowserMixin:
                 f"record length {len(record)} for image index {self.imageindex}",
                 'GroundTruther', Qgis.Warning)
 
+    def _warn_image_missing(self, img_path: str, exc: Exception) -> None:
+        """An image referenced by the metadata can't be read — warn, don't crash.
+
+        Shows a transient hint in the QGIS status bar and logs the detail; the
+        metadata panel and map marker still update so browsing continues.
+        """
+        name = os.path.basename(img_path)
+        if hasattr(self, 'w'):
+            self.w.statusbar.showMessage(
+                f"Image not on disk: {name} — showing metadata only.", 8000)
+        QgsMessageLog.logMessage(
+            f"add_image: image not readable, skipping display "
+            f"[{img_path}] ({type(exc).__name__}: {exc})",
+            'GroundTruther', Qgis.Warning)
+
     def on_send(self):
         """Emit image path and metadata string to connected widgets."""
-        image_path = os.path.join(
+        image_path = img_mgr.image_path_or_default(
             self.dirname,
-            self.imageMetadata["Imagename"].iloc[self.imageindex] + ".jpg")
+            self.imageMetadata["Imagename"].iloc[self.imageindex])
         self.send_image_path.emit(image_path)
 
         # Build a metadata HTML summary from whatever columns are available
@@ -750,9 +784,9 @@ class ImageBrowserMixin:
         self._image_dock.hide()  # all plugin docks start hidden; user opens via toolbar
 
         # Toggle action in self.w toolbar so the user can re-open the dock
-        from groundtruther.mixins.toolbar_icons import make_toggle_icon
+        from groundtruther.mixins.toolbar_icons import make_toggle_icon, apply_icon
         self._image_dock_action = QAction(self)
-        self._image_dock_action.setIcon(make_toggle_icon("file-image.svg"))
+        apply_icon(self._image_dock_action, "file-image.svg")
         self._image_dock_action.setCheckable(True)
         self._image_dock_action.setChecked(False)
         self._image_dock_action.setToolTip("Show / hide the Image Browser")
@@ -767,7 +801,7 @@ class ImageBrowserMixin:
         # Builder) with or without the big image view open.
         self._image_nav_action = QAction(self)
         try:
-            self._image_nav_action.setIcon(make_toggle_icon("forward.svg"))
+            apply_icon(self._image_nav_action, "forward.svg")
         except Exception:
             self._image_nav_action.setText("Idx")
         self._image_nav_action.setCheckable(True)
@@ -784,6 +818,9 @@ class ImageBrowserMixin:
 
         # Move actionAnnotation from self.w toolbar into the image browser toolbar
         self.w.toolBar.removeAction(self.w.actionAnnotation)
+        apply_icon(self.w.actionAnnotation, "pen-to-square.svg")
+        if not self.w.actionAnnotation.toolTip():
+            self.w.actionAnnotation.setToolTip("Annotation overlay")
         self._image_toolbar.addAction(self.w.actionAnnotation)
         # Replace the old showAnnotationThreshold connection with one that
         # shows/hides the confidence row inside this dock
@@ -809,6 +846,7 @@ class ImageBrowserMixin:
             Qt.DockWidgetArea.LeftDockWidgetArea, self._image_metadata_dock)
 
         self._meta_panel_action = QAction("Metadata", self._image_inner_window)
+        apply_icon(self._meta_panel_action, "table-list.svg")
         self._meta_panel_action.setCheckable(True)
         self._meta_panel_action.setToolTip("Show / hide the image metadata panel")
         self._meta_panel_action.toggled.connect(self._image_metadata_dock.setVisible)
@@ -817,11 +855,23 @@ class ImageBrowserMixin:
         self._image_toolbar.addSeparator()
         self._image_toolbar.addAction(self._meta_panel_action)
 
-        # Stereo display toggle: Full | Left | Right (exclusive). Hidden until a
-        # stereo pair is shown would be ideal, but a static group is simpler and
-        # harmless for single frames (split is a no-op there).
+        # Auto-stretch: percentile (2–98%) contrast stretch applied to each frame
+        # via pyqtgraph's display levels.  Off = the histogram's data min/max.
+        self._auto_stretch_action = QAction(self._image_inner_window)
+        self._auto_stretch_action.setCheckable(True)
+        self._auto_stretch_action.setToolTip(
+            "Auto-stretch contrast (2–98 % per frame)")
+        apply_icon(self._auto_stretch_action, "contrast.svg")
+        self._auto_stretch_action.toggled.connect(
+            lambda _checked: self._apply_auto_stretch())
+        self._image_toolbar.addAction(self._auto_stretch_action)
+
+        # Stereo display toggle: Full | Left | Right (exclusive) — picks which
+        # part of a HabCam side-by-side stereo frame to show.  Only meaningful for
+        # stereo pairs, so the whole group is hidden and revealed per-frame by
+        # ``_set_stereo_controls_visible`` (no effect / clutter on single frames).
         from qgis.PyQt.QtWidgets import QActionGroup
-        self._image_toolbar.addSeparator()
+        self._stereo_separator = self._image_toolbar.addSeparator()
         self._stereo_group = QActionGroup(self._image_inner_window)
         self._stereo_group.setExclusive(True)
         self._stereo_actions = {}
@@ -834,6 +884,7 @@ class ImageBrowserMixin:
             self._stereo_group.addAction(act)
             self._image_toolbar.addAction(act)
             self._stereo_actions[mode] = act
+        self._set_stereo_controls_visible(False)   # shown only for stereo frames
 
         QgsMessageLog.logMessage(
             "Image browser dock created", "GroundTruther", Qgis.Info)
@@ -845,6 +896,56 @@ class ImageBrowserMixin:
         self._stereo_display_mode = mode
         if self.imageMetadata is not None:
             self.add_image()
+
+    def _set_stereo_controls_visible(self, visible: bool) -> None:
+        """Show the Full/Left/Right toggle only for side-by-side stereo frames."""
+        sep = getattr(self, "_stereo_separator", None)
+        if sep is not None:
+            sep.setVisible(visible)
+        for act in getattr(self, "_stereo_actions", {}).values():
+            act.setVisible(visible)
+
+    @staticmethod
+    def _percentile_levels(arr, low: float = 2.0, high: float = 98.0):
+        """(low, high) display levels from the *low*/*high* percentiles of *arr*.
+
+        Operates on the colour channels jointly; subsamples big frames so the
+        stretch stays snappy while browsing.  Returns ``(None, None)`` if empty.
+        """
+        a = np.asarray(arr)
+        if a.ndim >= 3:
+            a = a[..., :3]
+        flat = a.reshape(-1)
+        if flat.size == 0:
+            return None, None
+        step = max(1, flat.size // 100_000)     # ~100k-sample estimate is plenty
+        flat = flat[::step]
+        lo, hi = np.percentile(flat, (low, high))
+        return float(lo), float(hi)
+
+    def _apply_auto_stretch(self) -> None:
+        """Apply / clear the percentile contrast stretch on the current frame."""
+        act = getattr(self, "_auto_stretch_action", None)
+        arr = getattr(self, "_displayed_arr", None)
+        if act is None or arr is None:
+            return
+        if not act.isChecked():
+            try:
+                self.imv.autoLevels()       # back to data min/max
+            except Exception as exc:        # noqa: BLE001 — display tweak only
+                log_exception("auto-stretch: autoLevels failed", exc, warn=True)
+            return
+        lo, hi = self._percentile_levels(arr)
+        if lo is None or hi <= lo:
+            return
+        try:
+            self.imv.setLevels(lo, hi)
+        except Exception:
+            try:                            # API differences across pyqtgraph
+                self.imv.getImageItem().setLevels([lo, hi])
+                self.imv.ui.histogram.setLevels(lo, hi)
+            except Exception as exc:        # noqa: BLE001
+                log_exception("auto-stretch: setLevels failed", exc, warn=True)
 
     def _on_image_conf_changed(self, value: float) -> None:
         """Update the threshold and immediately redraw the annotation overlay."""

--- a/mixins/layout_mixin.py
+++ b/mixins/layout_mixin.py
@@ -201,9 +201,9 @@ class LayoutMixin:
             mw.splitDockWidget(self, dock, Qt.Orientation.Vertical)
 
     def _add_layout_menu_action(self) -> None:
-        from groundtruther.mixins.toolbar_icons import make_icon
+        from groundtruther.mixins.toolbar_icons import apply_icon
         action = QAction(self)
-        action.setIcon(make_icon("arrows-rotate.svg"))
+        apply_icon(action, "arrows-rotate.svg")
         action.setToolTip("Restore default layout")
         action.triggered.connect(self._reset_default_layout)
         self.w.toolBar.addSeparator()

--- a/mixins/report_dock_mixin.py
+++ b/mixins/report_dock_mixin.py
@@ -21,8 +21,8 @@ def _make_toggle_action(title: str, tooltip: str, toggle_slot, visibility_slot,
     action = QAction(parent)
     if icon_svg:
         try:
-            from groundtruther.mixins.toolbar_icons import make_toggle_icon
-            action.setIcon(make_toggle_icon(icon_svg))
+            from groundtruther.mixins.toolbar_icons import apply_icon
+            apply_icon(action, icon_svg)
         except Exception:
             action.setText(title)
     else:

--- a/mixins/roughness_mixin.py
+++ b/mixins/roughness_mixin.py
@@ -38,6 +38,7 @@ from groundtruther.mixins.ui_style import (  # noqa: E402
     C_OK as _C_OK, C_WARN as _C_WARN, C_MUTED as _C_MUTED,
     VALUE_CSS as _VALUE_CSS, LABEL_CSS as _LABEL_CSS,
 )
+from groundtruther.mixins.toolbar_icons import iconize as _iconize  # noqa: E402
 
 
 class RoughnessMixin:
@@ -86,10 +87,10 @@ class RoughnessMixin:
         _iface.addDockWidget(Qt.DockWidgetArea(2), self._roughness_dock)  # right
         self._roughness_dock.hide()
 
-        from groundtruther.mixins.toolbar_icons import make_toggle_icon
+        from groundtruther.mixins.toolbar_icons import apply_icon
         self._roughness_action = QAction(self)
         try:
-            self._roughness_action.setIcon(make_toggle_icon("cubes.svg"))
+            apply_icon(self._roughness_action, "cubes.svg")
         except Exception:
             self._roughness_action.setText("Roughness")
         self._roughness_action.setCheckable(True)
@@ -204,6 +205,7 @@ class RoughnessMixin:
         self._rough_compute_btn = QPushButton("Compute roughness")
         self._rough_compute_btn.clicked.connect(
             self.compute_roughness_for_current_frame)
+        _iconize(self._rough_compute_btn, "arrows-rotate.svg")
         btn_row.addWidget(self._rough_compute_btn)
         self._rough_auto_check = QCheckBox("Auto")
         self._rough_auto_check.setToolTip(
@@ -247,10 +249,12 @@ class RoughnessMixin:
                 "Toggle measure mode, then click two points on the surface "
                 "(3-D / horizontal / vertical distance).")
             self._micro_dem_measure.toggled.connect(view.set_measure_mode)
+            _iconize(self._micro_dem_measure, "ruler-combined.svg")
             ctl.addWidget(self._micro_dem_measure)
             self._micro_dem_clear = QPushButton("Clear")
             self._micro_dem_clear.setToolTip("Clear the current measurement.")
             self._micro_dem_clear.clicked.connect(view.clear_measurement)
+            _iconize(self._micro_dem_clear, "eraser.svg")
             ctl.addWidget(self._micro_dem_clear)
             ctl.addWidget(QLabel("VE"))
             self._micro_dem_ve = QSpinBox()
@@ -682,20 +686,25 @@ class RoughnessMixin:
 
         preset_row = QHBoxLayout()
         browse_btn = QPushButton("Browse preset")
-        browse_btn.setToolTip("3 mm, anti-aliased — fast overview.")
+        browse_btn.setToolTip("Browse preset — 3 mm, anti-aliased, fast overview.")
         browse_btn.clicked.connect(lambda: self._apply_mosaic_preset("browse"))
+        _iconize(browse_btn, "image.svg")
         preset_row.addWidget(browse_btn)
         pub_btn = QPushButton("Publication preset")
-        pub_btn.setToolTip("ortho, 0.8 mm, lanczos, 8192 px, RGBA — near-native export.")
+        pub_btn.setToolTip(
+            "Publication preset — ortho, 0.8 mm, lanczos, 8192 px, RGBA, "
+            "near-native export.")
         pub_btn.clicked.connect(lambda: self._apply_mosaic_preset("publication"))
+        _iconize(pub_btn, "maximize.svg")
         preset_row.addWidget(pub_btn)
         mform.addRow(preset_row)
 
         self._mosaic_btn = QPushButton("Build mosaic")
         self._mosaic_btn.setToolTip(
-            "Composite the contiguous frames around the current one into a "
-            "georeferenced UTM mosaic (EPSG above) and add it to QGIS.")
+            "Build mosaic — composite the contiguous frames around the current "
+            "one into a georeferenced UTM mosaic (EPSG above) and add it to QGIS.")
         self._mosaic_btn.clicked.connect(self.build_mosaic_for_current_frame)
+        _iconize(self._mosaic_btn, "map-location-dot.svg")
         mform.addRow(self._mosaic_btn)
         v.addWidget(mbox)
 
@@ -708,11 +717,14 @@ class RoughnessMixin:
 
         btn_row = QHBoxLayout()
         save_btn = QPushButton("Save calibration")
-        save_btn.setToolTip("Persist these values for this dataset.")
+        save_btn.setToolTip("Save calibration — persist these values for this dataset.")
         save_btn.clicked.connect(self._save_georef_calibration)
+        _iconize(save_btn, "floppy-disk.svg")
         btn_row.addWidget(save_btn)
         clear_btn = QPushButton("Clear georef layers")
+        clear_btn.setToolTip("Clear georef layers added to QGIS by this panel.")
         clear_btn.clicked.connect(self._clear_georef_layers)
+        _iconize(clear_btn, "circle-xmark.svg")
         btn_row.addWidget(clear_btn)
         v.addLayout(btn_row)
 
@@ -758,7 +770,6 @@ class RoughnessMixin:
         direct = cfg["direct_url"]
         mosaic_direct = (direct.rsplit("/", 1)[0] + "/mosaic") if direct else None
         self._mosaic_btn.setEnabled(False)
-        self._mosaic_btn.setText("building…")
         self._georef_status.setText(
             f"building mosaic (±{int(self._mosaic_window.value())}) around {ref}…")
         if getattr(self, "_mosaic_warn", None) is not None:
@@ -784,8 +795,7 @@ class RoughnessMixin:
     def _reset_mosaic_button(self) -> None:
         btn = getattr(self, "_mosaic_btn", None)
         if btn is not None:
-            btn.setEnabled(True)
-            btn.setText("Build mosaic")
+            btn.setEnabled(True)   # icon-only; label lives in the tooltip
 
     def _on_mosaic_success(self, reference_key: str, result: dict) -> None:
         self._mosaic_task = None
@@ -1283,8 +1293,8 @@ class RoughnessMixin:
     def _set_roughness_busy(self, busy: bool) -> None:
         btn = getattr(self, "_rough_compute_btn", None)
         if btn is not None:
-            btn.setEnabled(not busy)
-            btn.setText("computing…" if busy else "Compute roughness")
+            btn.setEnabled(not busy)   # icon-only; status is shown in the panel
+            btn.setToolTip("computing…" if busy else "Compute roughness")
 
     # ------------------------------------------------------------------ #
     # Display                                                              #

--- a/mixins/session_mixin.py
+++ b/mixins/session_mixin.py
@@ -36,9 +36,9 @@ class SessionMixin:
         (a configured session file then takes precedence).
         """
         try:
-            from groundtruther.mixins.toolbar_icons import make_icon
+            from groundtruther.mixins.toolbar_icons import apply_icon
             action = QAction(self)
-            action.setIcon(make_icon("floppy-disk.svg"))
+            apply_icon(action, "floppy-disk.svg")
             action.setToolTip("Save GroundTruther session")
             action.triggered.connect(lambda: self.save_session())
             self.w.toolBar.addAction(action)

--- a/mixins/settings_mixin.py
+++ b/mixins/settings_mixin.py
@@ -156,7 +156,14 @@ class SettingsMixin:
         # reference-surface GeoTIFF, …) without a plugin restart.
         if getattr(self, "querybuilder", None) is not None:
             dialog.settings_saved.connect(self.querybuilder.refresh_settings)
-        dialog.exec()
+        act = getattr(self.w, "actionWizard", None)
+        if act is not None and act.isCheckable():
+            act.setChecked(True)            # highlight the toolbar button while open
+        try:
+            dialog.exec()
+        finally:
+            if act is not None and act.isCheckable():
+                act.setChecked(False)
 
     def _open_config_dialog(self):
         """Open the config dialog without connecting to ``_apply_settings``.

--- a/mixins/toolbar_icons.py
+++ b/mixins/toolbar_icons.py
@@ -6,16 +6,160 @@ Usage::
 
     action.setIcon(make_toggle_icon("file-image.svg"))   # checkable action
     action.setIcon(make_icon("arrows-rotate.svg"))        # plain action
+
+Prefer ``iconize(widget, svg)`` or ``apply_icon(target, svg)`` over a bare
+``setIcon`` — those register the target so it re-tints **live** when the OS / QGIS
+UI theme switches between light and dark (no plugin reload needed).
 """
 import os
+import weakref
 
 _ICONS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "qtui", "icons")
 
-# Unchecked / inactive state
-_COLOR_OFF = (150, 150, 150, 200)   # neutral gray, slightly transparent
+# Base tints are picked from the active Qt palette at icon-build time so the set
+# adapts to light vs dark themes — covers both the OS style and the QGIS UI theme
+# (Default / Night Mapping / Blend of Gray), which both drive the app palette.
+#
+# Light theme: a neutral mid-gray reads well on a pale toolbar.
+# Dark theme : a much brighter gray so the icon doesn't disappear into the dark.
+_COLOR_OFF_LIGHT = (150, 150, 150, 200)   # neutral gray on a light toolbar
+_COLOR_OFF_DARK  = (205, 205, 205, 235)   # bright gray on a dark toolbar
+# Checked / active state — QGIS-ish blue, nudged brighter on dark themes.
+_COLOR_ON_LIGHT  = (65, 165, 230, 255)
+_COLOR_ON_DARK   = (95, 185, 250, 255)
 
-# Checked / active state
-_COLOR_ON  = (65, 165, 230, 255)    # QGIS-ish light blue, fully opaque
+
+def _is_dark_theme() -> bool:
+    """True when the active Qt palette is dark (perceived window luminance < 50%)."""
+    try:
+        from qgis.PyQt.QtWidgets import QApplication
+        from qgis.PyQt.QtGui import QPalette
+        app = QApplication.instance()
+        if app is None:
+            return False
+        c = app.palette().color(QPalette.ColorRole.Window)
+        return (0.299 * c.red() + 0.587 * c.green() + 0.114 * c.blue()) < 128
+    except Exception:
+        return False
+
+
+def _color_off() -> tuple:
+    return _COLOR_OFF_DARK if _is_dark_theme() else _COLOR_OFF_LIGHT
+
+
+def _color_on() -> tuple:
+    return _COLOR_ON_DARK if _is_dark_theme() else _COLOR_ON_LIGHT
+
+
+# --- live re-tint on theme change ------------------------------------------
+# Each iconized target is registered (weakly) with its SVG + size; when the app
+# palette changes (OS dark mode, or QGIS UI theme switch) every registered icon
+# is rebuilt at the new tint.  Targets that have been deleted are pruned.
+#
+# We listen on the application ``paletteChanged`` signal ONLY.  We deliberately
+# do NOT install an event filter on the QApplication: a filter on the app object
+# receives *every* event for *every* object in QGIS and runs Python per-event,
+# which makes the whole UI hang (especially during startup).
+_REGISTRY = []          # list of (weakref_to_target, svg_name, size)
+_HOOKS = []             # list of weakrefs to callables run after each retint
+_SIGNAL_CONNECTED = False
+
+
+def _retint_target(target, svg_name, size) -> None:
+    """Rebuild + apply one target's icon at the current theme."""
+    try:
+        checkable = bool(target.isCheckable())
+    except Exception:
+        checkable = False
+    icon = make_toggle_icon(svg_name, size) if checkable else make_icon(svg_name, size)
+    target.setIcon(icon)
+
+
+def retint_all() -> None:
+    """Rebuild every registered icon for the current palette; prune dead ones."""
+    alive = []
+    for ref, svg, size in _REGISTRY:
+        target = ref()
+        if target is None:
+            continue
+        try:
+            _retint_target(target, svg, size)
+            alive.append((ref, svg, size))
+        except RuntimeError:        # underlying C++ object already gone
+            continue
+    _REGISTRY[:] = alive
+    live_hooks = []
+    for hook in _HOOKS:
+        cb = hook()
+        if cb is None:
+            continue
+        live_hooks.append(hook)
+        try:
+            cb()
+        except Exception:
+            pass
+    _HOOKS[:] = live_hooks
+
+
+def add_retint_hook(callback) -> None:
+    """Register *callback* (no args) to run after each live re-tint (held weakly).
+
+    Use for icons that can't be expressed as a single registered target — e.g.
+    the video player's cached play / pause icons, which the hook rebuilds and
+    re-applies according to the current playback state.
+    """
+    try:
+        ref = weakref.WeakMethod(callback)
+    except TypeError:
+        ref = weakref.ref(callback)
+    _HOOKS.append(ref)
+    _install_watcher()
+
+
+def _register_icon(target, svg_name, size) -> None:
+    try:
+        ref = weakref.ref(target)
+    except TypeError:
+        ref = (lambda t=target: t)      # not weakref-able → hold strongly
+    _REGISTRY.append((ref, svg_name, size))
+    _install_watcher()
+
+
+def _install_watcher() -> None:
+    """Connect (once) the application ``paletteChanged`` signal to a re-tint.
+
+    Cheap: the signal only fires when the application palette actually changes
+    (OS dark-mode toggle, QGIS UI-theme switch), never per ordinary event.
+    """
+    global _SIGNAL_CONNECTED
+    if _SIGNAL_CONNECTED:
+        return
+    try:
+        from qgis.PyQt.QtWidgets import QApplication
+        app = QApplication.instance()
+        if app is None:
+            return
+        if hasattr(app, "paletteChanged"):
+            app.paletteChanged.connect(_on_palette_changed)
+        _SIGNAL_CONNECTED = True          # don't retry even if the signal is absent
+    except Exception:
+        pass
+
+
+def _on_palette_changed(*_args) -> None:
+    retint_all()
+
+
+def apply_icon(target, svg_name: str, size: int = 22):
+    """Set a theme-adaptive icon on *target* and register it for live re-tint.
+
+    Drop-in for ``target.setIcon(make_toggle_icon(...))`` / ``make_icon(...)`` —
+    two-state for checkable targets, single otherwise — that also follows later
+    light/dark theme switches.  Text is left untouched.
+    """
+    _register_icon(target, svg_name, size)
+    _retint_target(target, svg_name, size)
+    return target
 
 
 def _icon_path(name: str) -> str:
@@ -48,10 +192,10 @@ def make_toggle_icon(svg_name: str, size: int = 22):
         path = _icon_path(svg_name)
         icon = QIcon()
         icon.addPixmap(
-            _tinted_pixmap(path, _COLOR_OFF, size),
+            _tinted_pixmap(path, _color_off(), size),
             QIcon.Mode.Normal, QIcon.State.Off)
         icon.addPixmap(
-            _tinted_pixmap(path, _COLOR_ON, size),
+            _tinted_pixmap(path, _color_on(), size),
             QIcon.Mode.Normal, QIcon.State.On)
         return icon
     except Exception:
@@ -64,7 +208,36 @@ def make_icon(svg_name: str, size: int = 22):
     try:
         path = _icon_path(svg_name)
         icon = QIcon()
-        icon.addPixmap(_tinted_pixmap(path, _COLOR_OFF, size))
+        icon.addPixmap(_tinted_pixmap(path, _color_off(), size))
         return icon
     except Exception:
         return QIcon(_icon_path(svg_name))
+
+
+def iconize(widget, svg_name: str, tooltip: str = None, *, size: int = 22):
+    """Make *widget* an on-theme, icon-only control.
+
+    Works for ``QAction``, ``QPushButton`` and ``QToolButton``.  Applies the
+    tinted SVG icon (two-state for checkable widgets, single for the rest), moves
+    the current text into the tooltip (unless *tooltip* is given), and — for
+    push/tool buttons — clears the text + switches to icon-only display.  Toolbar
+    ``QAction`` text is kept (so menus/accessibility still read), since toolbars
+    already render icon-only.
+    """
+    from qgis.PyQt.QtWidgets import QAbstractButton, QToolButton
+    from qgis.PyQt.QtCore import Qt
+    try:
+        checkable = bool(widget.isCheckable())
+    except Exception:
+        checkable = False
+    icon = make_toggle_icon(svg_name, size) if checkable else make_icon(svg_name, size)
+    tip = tooltip or widget.toolTip() or widget.text()
+    widget.setIcon(icon)
+    _register_icon(widget, svg_name, size)       # follow live theme switches
+    if tip:
+        widget.setToolTip(tip)
+    if isinstance(widget, QAbstractButton):
+        widget.setText("")                       # icon-only; tooltip is the label
+        if isinstance(widget, QToolButton):
+            widget.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+    return widget

--- a/mixins/video_annotation_mixin.py
+++ b/mixins/video_annotation_mixin.py
@@ -101,12 +101,15 @@ class VideoAnnotationMixin:
         """Add annotation actions to the video player's embedded toolbar."""
         toolbar = self._video_player.player_toolbar
 
+        from groundtruther.mixins.toolbar_icons import iconize
+
         self._video_ann_action = QAction("Annotate", self)
         self._video_ann_action.setCheckable(True)
         self._video_ann_action.setToolTip(
             "Show / hide the video annotation editor panel")
         self._video_ann_action.toggled.connect(
             self._toggle_video_annotation_editor)
+        iconize(self._video_ann_action, "table.svg")
         toolbar.addAction(self._video_ann_action)
 
         toolbar.addSeparator()
@@ -117,6 +120,7 @@ class VideoAnnotationMixin:
             "Click and drag on the video frame to draw a new bounding box")
         self._video_ann_draw_action.toggled.connect(
             self._toggle_video_draw_mode)
+        iconize(self._video_ann_draw_action, "mActionSelectRectangle.svg")
         self._video_ann_draw_action.setVisible(False)
         toolbar.addAction(self._video_ann_draw_action)
 

--- a/mixins/video_browser_mixin.py
+++ b/mixins/video_browser_mixin.py
@@ -133,9 +133,9 @@ class VideoBrowserMixin:
     def _wire_video_toolbar_action(self) -> None:
         """Add a 'Video Player' toggle to the plugin toolbar if one exists."""
         try:
-            from groundtruther.mixins.toolbar_icons import make_toggle_icon
+            from groundtruther.mixins.toolbar_icons import apply_icon
             action = QAction(self)
-            action.setIcon(make_toggle_icon("forward.svg"))
+            apply_icon(action, "video.svg")
             action.setCheckable(True)
             action.setToolTip("Show / hide the Video Player")
             action.triggered.connect(self._toggle_video_dock)

--- a/pygui/cheatsheet.py
+++ b/pygui/cheatsheet.py
@@ -54,9 +54,9 @@ class CheatSheetButton(QToolButton):
         self._png = os.path.join(CHEATS_DIR, png)
         self._title = title
         self._dlg = None
-        self.setText("ⓘ")
+        from groundtruther.mixins.toolbar_icons import iconize
+        iconize(self, "circle-info.svg", f"Formulae & symbols — {title}")
         self.setAutoRaise(True)
-        self.setToolTip(f"Formulae & symbols — {title}")
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self.clicked.connect(self._show)
 

--- a/pygui/grass_mdi_gui.py
+++ b/pygui/grass_mdi_gui.py
@@ -116,16 +116,17 @@ class GrassTools(QMainWindow):
         self.module_search.installEventFilter(self)
         self.module_search.returnPressed.connect(self.open_typed_module)
         self.moduleToolBar.addWidget(self.module_search)
+        from groundtruther.mixins.toolbar_icons import iconize
         self.open_module_btn = QToolButton()
         self.open_module_btn.setText("Open")
         self.open_module_btn.setToolTip("Build & open a dialog for this GRASS module")
         self.open_module_btn.clicked.connect(self.open_typed_module)
+        iconize(self.open_module_btn, "screwdriver-wrench.svg")
         self.moduleToolBar.addWidget(self.open_module_btn)
 
         self.grass_layers_view = QToolButton()
-        grass_layers_view_icon = QIcon(":/icons/qtui/icons/table-list.svg")
         self.grass_layers_view.setToolTip("Show/Hide GRASS Layers")
-        self.grass_layers_view.setIcon(grass_layers_view_icon)
+        iconize(self.grass_layers_view, "table-list.svg")
         self.moduleToolBar.addWidget(self.grass_layers_view)
         self.grass_layers_view.clicked.connect(self.toggle_grass_layers_table)
 
@@ -134,12 +135,14 @@ class GrassTools(QMainWindow):
         self.import_raster_btn.setText("Import Raster")
         self.import_raster_btn.setToolTip("Import a raster file into the active GRASS environment")
         self.import_raster_btn.clicked.connect(lambda: self.import_to_env("raster"))
+        iconize(self.import_raster_btn, "file-image.svg")
         self.moduleToolBar.addWidget(self.import_raster_btn)
 
         self.import_vector_btn = QToolButton()
         self.import_vector_btn.setText("Import Vector")
         self.import_vector_btn.setToolTip("Import a vector file into the active GRASS environment")
         self.import_vector_btn.clicked.connect(lambda: self.import_to_env("vector"))
+        iconize(self.import_vector_btn, "map-location-dot.svg")
         self.moduleToolBar.addWidget(self.import_vector_btn)
 
         # Add the checked GRASS raster(s) from the table into the QGIS project
@@ -147,6 +150,7 @@ class GrassTools(QMainWindow):
         self.add_to_qgis_btn.setText("Add to QGIS")
         self.add_to_qgis_btn.setToolTip("Add the checked GRASS raster(s) to the QGIS project")
         self.add_to_qgis_btn.clicked.connect(self.add_selected_to_qgis)
+        iconize(self.add_to_qgis_btn, "arrow-up-right-dots.svg")
         self.moduleToolBar.addWidget(self.add_to_qgis_btn)
 
         # Show/hide the active env's current computational region on the map
@@ -154,6 +158,7 @@ class GrassTools(QMainWindow):
         self.show_region_btn.setText("Region")
         self.show_region_btn.setCheckable(True)
         self.show_region_btn.setToolTip("Show/hide the active GRASS computational region on the map")
+        iconize(self.show_region_btn, "mActionSelectRectangle.svg")
         self.show_region_btn.clicked.connect(self.parent.toggle_grass_region)
         self.moduleToolBar.addWidget(self.show_region_btn)
 

--- a/pygui/grass_module_runner.py
+++ b/pygui/grass_module_runner.py
@@ -54,6 +54,11 @@ class ModuleRunnerWidget(QWidget):
         self.cancel = QPushButton("Cancel")
         self.cancel.setEnabled(False)
         self.exit = QPushButton("Close")
+        from groundtruther.mixins.toolbar_icons import iconize
+        iconize(self.reload_layers, "arrows-rotate.svg", "Reload layers")
+        iconize(self.run, "play.svg", "Run module")
+        iconize(self.cancel, "circle-xmark.svg", "Cancel")
+        iconize(self.exit, "power-off.svg", "Close")
         row.addWidget(self.reload_layers)
         row.addWidget(self.run)
         row.addWidget(self.cancel)

--- a/pygui/hbc_browser_gui.py
+++ b/pygui/hbc_browser_gui.py
@@ -19,3 +19,27 @@ class HBCBrowserGui(QtWidgets.QMainWindow, Ui_MainWindow):
     def __init__(self):
         QtWidgets.QMainWindow.__init__(self)
         self.setupUi(self)
+        self._harmonize_action_icons()
+
+    def _harmonize_action_icons(self):
+        """Replace the Designer raster icons with on-theme tinted SVGs."""
+        from groundtruther.mixins.toolbar_icons import iconize
+        # Make the dialog-opening actions checkable so they highlight (blue
+        # toggle-icon) while their (modal) window is open — the open handlers
+        # toggle the checked state around exec().
+        for name in ("actionWizard", "actiongrass_settings"):
+            act = getattr(self, name, None)
+            if act is not None:
+                act.setCheckable(True)
+        for name, svg, tip in (
+            ("actionWizard", "screwdriver-wrench.svg", "Preferences / settings"),
+            ("actionTools", "table-list.svg", "Tools"),
+            ("actionQuit", "power-off.svg", "Quit"),
+            ("actionAnnotation", "pen-to-square.svg", "Image annotation overlay"),
+            ("actionGisTools", "GrassProperties.svg", "GIS Tools (GRASS)"),
+            ("actionImageBrowser", "file-image.svg", "Image Browser"),
+            ("actiongrass_settings", "grass_location.svg", "GRASS environment settings"),
+        ):
+            act = getattr(self, name, None)
+            if act is not None:
+                iconize(act, svg, tip)

--- a/pygui/kmlsave_gui.py
+++ b/pygui/kmlsave_gui.py
@@ -199,6 +199,55 @@ class SaveKml(QWidget, Ui_Form):
         self.report_items = []
 
         self.editor_save.clicked.connect(self.SavetoPDF)
+        self._harmonize_icons()
+
+    def _harmonize_icons(self):
+        """Swap the Designer raster icons for on-theme tinted SVGs (icon-only).
+
+        Covers the rich-text editor toolbar, the report action buttons, and the
+        2D/3D/selected-points products.  The compact text products (SU / Σ / H /
+        IMG / Rgh / DEM / Spec / Mos) and the colour-swatch pickers are left as
+        they are — their short labels / live colour carry meaning an icon can't.
+        """
+        from groundtruther.mixins.toolbar_icons import iconize
+        mapping = {
+            # rich-text editor
+            "editor_bold": "bold.svg", "editor_italic": "italic.svg",
+            "editor_underline": "underline.svg",
+            "editor_align_left": "align-left.svg",
+            "editor_align_center": "align-center.svg",
+            "editor_align_right": "align-right.svg",
+            "editor_align_justify": "align-justify.svg",
+            "editor_undo": "arrow-rotate-left.svg",
+            "editor_redo": "arrow-rotate-right.svg",
+            "editor_copy": "copy.svg", "editor_cut": "cut.svg",
+            "editor_paste": "paste.svg", "editor_select_all": "select-all.svg",
+            # report actions
+            "save": "floppy-disk.svg", "update": "arrows-rotate.svg",
+            "opendir": "folder-open.svg", "clean": "eraser.svg",
+            "addimage": "file-image.svg", "addlink": "link.svg",
+            "editor_save": "file-export.svg",
+            # graph products defined in the .ui
+            "get_2dgraph": "chart-line.svg", "get_3dgraph": "cubes.svg",
+            "get_selected_points": "map-location-dot.svg",
+        }
+        tips = {
+            "editor_bold": "Bold", "editor_italic": "Italic",
+            "editor_underline": "Underline", "editor_align_left": "Align left",
+            "editor_align_center": "Align center", "editor_align_right": "Align right",
+            "editor_align_justify": "Justify", "editor_undo": "Undo",
+            "editor_redo": "Redo", "editor_copy": "Copy", "editor_cut": "Cut",
+            "editor_paste": "Paste", "editor_select_all": "Select all",
+            "save": "Save report (KMZ)", "update": "Update report preview",
+            "opendir": "Open output directory", "clean": "Clear the editor",
+            "addimage": "Add image", "addlink": "Add link",
+            "editor_save": "Save to PDF", "get_2dgraph": "Add 2-D graph",
+            "get_3dgraph": "Add 3-D graph", "get_selected_points": "Add selected points",
+        }
+        for name, svg in mapping.items():
+            btn = getattr(self, name, None)
+            if btn is not None:
+                iconize(btn, svg, tips.get(name))
 
     def _add_report_item(self, item):
         """Record a product for the styled HTML report (skips empty ones)."""

--- a/pygui/querybuilder_gui.py
+++ b/pygui/querybuilder_gui.py
@@ -269,6 +269,9 @@ class QueryBuilder(QWidget, Ui_Form):
         # self.clean_graph.clicked.connect(self.refresh_settings)
         self.reload_settings.clicked.connect(self.refresh_settings)
         self.add_graph.clicked.connect(self.grab_tab)
+        from groundtruther.mixins.toolbar_icons import iconize as _iconize
+        _iconize(self.reload_settings, "arrows-rotate.svg", "Reload settings")
+        _iconize(self.add_graph, "image.svg", "Add graph (snapshot current tab)")
         # self.tabWidget.setEnabled(False)
         # get the settings
         # add the soundings as an entry to qb_pointdatasource
@@ -282,6 +285,7 @@ class QueryBuilder(QWidget, Ui_Form):
         self.set_backscatter_field.currentIndexChanged.connect(self.get_backscatter_field)
         self.draw_graph.clicked.connect(self.get_shape_geom)
         self.draw_graph.clicked.connect(self.plot_hist)
+        _iconize(self.draw_graph, "chart-line.svg", "Draw graph")
 
         self.graphicsView = pg.PlotWidget(self.tab_2)
         self.graphicsView.setObjectName("graphicsView")
@@ -343,9 +347,12 @@ class QueryBuilder(QWidget, Ui_Form):
         self.ref3d_measure.setToolTip(
             "Toggle measure mode, then click two points on the surface")
         self.ref3d_measure.toggled.connect(self.glw_ref.set_measure_mode)
+        _iconize(self.ref3d_measure, "ruler-combined.svg")
         ref3d_ctrl.addWidget(self.ref3d_measure)
         self.ref3d_clear = QPushButton("Clear")
+        self.ref3d_clear.setToolTip("Clear the current measurement.")
         self.ref3d_clear.clicked.connect(self.glw_ref.clear_measurement)
+        _iconize(self.ref3d_clear, "eraser.svg")
         ref3d_ctrl.addWidget(self.ref3d_clear)
         # Vertical exaggeration slider (1× … 20×)
         ref3d_ctrl.addWidget(QLabel("VE"))
@@ -382,6 +389,7 @@ class QueryBuilder(QWidget, Ui_Form):
         self.plothist_opt = QHBoxLayout()
         self.plot_button = QPushButton('Refresh')
         self.plot_button.clicked.connect(self.plot_hist)
+        _iconize(self.plot_button, "arrows-rotate.svg", "Refresh histogram")
         self.plotnine_window = Window()
         self.plotting_widget = QWidget()
         self.plot_layout = QVBoxLayout()
@@ -431,9 +439,10 @@ class QueryBuilder(QWidget, Ui_Form):
         # cross hair
 
     def add_image_link(self):
+        from groundtruther.gt import image_manager as img_mgr
         image__path_selected = ''
         for i in self.image_selection_pd['Imagename']:
-            image_path = os.path.join(self.dirname, i+".jpg")
+            image_path = img_mgr.image_path_or_default(self.dirname, i)
             image__path_selected += f'<img src="{image_path}" alt="Smiley face" height="300"><br>'
                 # link = self.textlink()
         self.image_selection.setHtml(image__path_selected)
@@ -1202,10 +1211,11 @@ class QueryBuilder(QWidget, Ui_Form):
 
     def _selected_image_paths(self):
         """Absolute paths of the sampling-shape images that exist on disk."""
+        from groundtruther.gt import image_manager as img_mgr
         paths = []
         for name in self.image_selection_pd['Imagename']:
-            image_path = os.path.join(self.dirname, name + ".jpg")
-            if os.path.exists(image_path):
+            image_path = img_mgr.resolve_image_path(self.dirname, name)
+            if image_path:
                 paths.append(image_path)
         return paths
 

--- a/pygui/video_player_gui.py
+++ b/pygui/video_player_gui.py
@@ -264,21 +264,32 @@ class VideoPlayerWidget(QWidget):
         # --- Playback controls ---
         controls = QHBoxLayout()
 
+        from groundtruther.mixins.toolbar_icons import iconize, make_icon
+
         self._btn_prev = QToolButton()
-        self._btn_prev.setText("◀◀")
         self._btn_prev.setToolTip("Step back one frame")
         self._btn_prev.clicked.connect(self.step_backward)
+        iconize(self._btn_prev, "backward.svg")
         controls.addWidget(self._btn_prev)
 
+        # Play button manages its own icon (play <-> pause swap on toggle), so it
+        # is driven by a retint hook rather than the registry's auto re-tint.
         self._btn_play = QPushButton("▶  Play")
         self._btn_play.setCheckable(True)
         self._btn_play.toggled.connect(self._on_play_toggled)
+        self._btn_play.setText("")
+        self._btn_play.setToolTip("Play / pause")
+        self._icon_play = make_icon("play.svg")
+        self._icon_pause = make_icon("pause.svg")
+        self._btn_play.setIcon(self._icon_play)
+        from groundtruther.mixins.toolbar_icons import add_retint_hook
+        add_retint_hook(self._retint_transport_icons)
         controls.addWidget(self._btn_play)
 
         self._btn_next = QToolButton()
-        self._btn_next.setText("▶▶")
         self._btn_next.setToolTip("Step forward one frame")
         self._btn_next.clicked.connect(self.step_forward)
+        iconize(self._btn_next, "forward.svg")
         controls.addWidget(self._btn_next)
 
         controls.addStretch()
@@ -659,7 +670,7 @@ class VideoPlayerWidget(QWidget):
         self._playing = False
         self._btn_play.blockSignals(True)
         self._btn_play.setChecked(False)
-        self._btn_play.setText("▶  Play")
+        self._btn_play.setIcon(self._icon_play)
         self._btn_play.blockSignals(False)
 
     # ------------------------------------------------------------------ #
@@ -671,10 +682,17 @@ class VideoPlayerWidget(QWidget):
         speed = self._speed_spinbox.value() if hasattr(self, "_speed_spinbox") else 1.0
         return max(self._MIN_INTERVAL_MS, int(1000 / (self._fps * speed)))
 
+    def _retint_transport_icons(self) -> None:
+        """Rebuild the cached play/pause icons at the current theme + reapply."""
+        from groundtruther.mixins.toolbar_icons import make_icon
+        self._icon_play = make_icon("play.svg")
+        self._icon_pause = make_icon("pause.svg")
+        self._btn_play.setIcon(self._icon_pause if self._playing else self._icon_play)
+
     def _on_play_toggled(self, checked: bool) -> None:
         if checked:
             self._playing = True
-            self._btn_play.setText("⏸  Pause")
+            self._btn_play.setIcon(self._icon_pause)
             self._timer.start(self._timer_interval())
             self.playback_started.emit()
         else:

--- a/qtui/icons/align-center.svg
+++ b/qtui/icons/align-center.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="2.4" rx="1"/><rect x="6" y="10.8" width="12" height="2.4" rx="1"/><rect x="4" y="16.6" width="16" height="2.4" rx="1"/></svg>

--- a/qtui/icons/align-justify.svg
+++ b/qtui/icons/align-justify.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="2.4" rx="1"/><rect x="3" y="10.8" width="18" height="2.4" rx="1"/><rect x="3" y="16.6" width="18" height="2.4" rx="1"/></svg>

--- a/qtui/icons/align-left.svg
+++ b/qtui/icons/align-left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="2.4" rx="1"/><rect x="3" y="10.8" width="12" height="2.4" rx="1"/><rect x="3" y="16.6" width="16" height="2.4" rx="1"/></svg>

--- a/qtui/icons/align-right.svg
+++ b/qtui/icons/align-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="2.4" rx="1"/><rect x="9" y="10.8" width="12" height="2.4" rx="1"/><rect x="5" y="16.6" width="16" height="2.4" rx="1"/></svg>

--- a/qtui/icons/bold.svg
+++ b/qtui/icons/bold.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="4.5" y="19" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="900">B</text></svg>

--- a/qtui/icons/circle-info.svg
+++ b/qtui/icons/circle-info.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9.5" fill="none" stroke="#000" stroke-width="2"/><circle cx="12" cy="7.6" r="1.4"/><rect x="10.8" y="10.5" width="2.4" height="7" rx="1"/></svg>

--- a/qtui/icons/contrast.svg
+++ b/qtui/icons/contrast.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" fill="none" stroke="#000" stroke-width="2"/><path d="M12 3a9 9 0 0 0 0 18z"/></svg>

--- a/qtui/icons/cut.svg
+++ b/qtui/icons/cut.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2"><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><line x1="8.6" y1="7.5" x2="20" y2="18"/><line x1="8.6" y1="16.5" x2="20" y2="6"/></svg>

--- a/qtui/icons/file-export.svg
+++ b/qtui/icons/file-export.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"><path d="M14 2H6v20h12V6z"/><path d="M14 2v4h4"/><path d="M12 10v7m0 0l-3-3m3 3l3-3"/></svg>

--- a/qtui/icons/italic.svg
+++ b/qtui/icons/italic.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="6" y="19" font-family="Georgia, 'Times New Roman', serif" font-size="20" font-style="italic" font-weight="bold">I</text></svg>

--- a/qtui/icons/paste.svg
+++ b/qtui/icons/paste.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2"><rect x="6" y="5" width="12" height="16" rx="1.5"/><path d="M9 5V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v1" fill="#000"/></svg>

--- a/qtui/icons/pause.svg
+++ b/qtui/icons/pause.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="6" y="4" width="4.5" height="16" rx="1"/><rect x="13.5" y="4" width="4.5" height="16" rx="1"/></svg>

--- a/qtui/icons/play.svg
+++ b/qtui/icons/play.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6 4.5l13 7.5-13 7.5z"/></svg>

--- a/qtui/icons/query.svg
+++ b/qtui/icons/query.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2"><circle cx="10" cy="10" r="6"/><line x1="14.5" y1="14.5" x2="21" y2="21" stroke-width="2.6"/></svg>

--- a/qtui/icons/select-all.svg
+++ b/qtui/icons/select-all.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" fill="none" stroke="#000" stroke-width="2" stroke-dasharray="3.2 2.4"/><rect x="8" y="8" width="8" height="8" rx="1"/></svg>

--- a/qtui/icons/table.svg
+++ b/qtui/icons/table.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="1.5"/><line x1="3" y1="9.5" x2="21" y2="9.5"/><line x1="9.5" y1="9.5" x2="9.5" y2="20"/><line x1="15" y1="9.5" x2="15" y2="20"/></svg>

--- a/qtui/icons/target.svg
+++ b/qtui/icons/target.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2"><circle cx="12" cy="12" r="7.5"/><circle cx="12" cy="12" r="2.4" fill="#000" stroke="none"/><line x1="12" y1="1.5" x2="12" y2="5"/><line x1="12" y1="19" x2="12" y2="22.5"/><line x1="1.5" y1="12" x2="5" y2="12"/><line x1="19" y1="12" x2="22.5" y2="12"/></svg>

--- a/qtui/icons/underline.svg
+++ b/qtui/icons/underline.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><text x="5" y="16" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="bold">U</text><rect x="4" y="19.5" width="14" height="2.2" rx="1"/></svg>

--- a/qtui/icons/video.svg
+++ b/qtui/icons/video.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="2" y="5" width="20" height="14" rx="2.5" fill="none" stroke="#000" stroke-width="2"/><path d="M10 8.5l6 3.5-6 3.5z"/></svg>

--- a/tests/unit/test_image_manager.py
+++ b/tests/unit/test_image_manager.py
@@ -72,3 +72,36 @@ def test_filter_annotations_by_confidence():
 def test_filter_annotations_handles_missing():
     assert im.filter_annotations_by_confidence(None, 0.5) == []
     assert im.filter_annotations_by_confidence(np.nan, 0.5) == []
+
+
+# --- image-file resolution (mono .jpg vs stereo _orig.png) ------------------
+
+def test_resolve_image_path_mono_jpg(tmp_path):
+    (tmp_path / "frame1.jpg").write_bytes(b"x")
+    assert im.resolve_image_path(tmp_path, "frame1") == str(tmp_path / "frame1.jpg")
+
+
+def test_resolve_image_path_stereo_orig_png(tmp_path):
+    (tmp_path / "frame2_orig.png").write_bytes(b"x")
+    assert im.resolve_image_path(tmp_path, "frame2") == str(tmp_path / "frame2_orig.png")
+
+
+def test_resolve_image_path_missing_returns_none(tmp_path):
+    assert im.resolve_image_path(tmp_path, "nope") is None
+    assert im.resolve_image_path("", "frame") is None
+    assert im.resolve_image_path(tmp_path, None) is None
+
+
+def test_resolve_image_path_preferred_does_not_break_other_pattern(tmp_path):
+    # Resolving a stereo frame must not stop a later mono frame from resolving.
+    (tmp_path / "a_orig.png").write_bytes(b"x")
+    (tmp_path / "b.jpg").write_bytes(b"x")
+    assert im.resolve_image_path(tmp_path, "a").endswith("a_orig.png")
+    assert im.resolve_image_path(tmp_path, "b").endswith("b.jpg")
+
+
+def test_image_path_or_default_falls_back(tmp_path):
+    (tmp_path / "real_orig.png").write_bytes(b"x")
+    assert im.image_path_or_default(tmp_path, "real").endswith("real_orig.png")
+    # missing -> stable <name>.jpg path (for display / not-found warnings)
+    assert im.image_path_or_default(tmp_path, "ghost") == str(tmp_path / "ghost.jpg")


### PR DESCRIPTION
A UI-polish + robustness pass over the plugin, built and verified incrementally during live testing.

## Icons
- **Harmonized** every toolbar / dock / dialog button to on-theme, **icon-only tinted SVGs** through a shared `iconize()` / `apply_icon()` helper. Adds ~17 new SVG assets (bold/italic/underline, align ×4, cut/paste/select-all, play/pause/video, target, contrast, circle-info, table, query, file-export).
- **Theme-adaptive tint** — base colour derived from the active Qt palette, so icons brighten on dark themes (OS dark mode or QGIS Night Mapping).
- **Live re-tint** — registered icons rebuild on the application `paletteChanged` signal, no plugin reload needed.
- Deliberately **no QApplication event filter** (an earlier attempt routed every event through Python and hung QGIS at startup — removed).
- Preferences + GRASS-settings actions now **highlight while their (modal) window is open**; the main-toolbar "Image Browser" map-seek tool is now a **target** icon.

## Image browser
- **Missing / unreadable frames no longer crash** browsing — warn in the status bar + log, keep updating the metadata panel and map marker; only the picture is skipped.
- **Mono / stereo path resolution** — metadata stores a bare frame name; the mono delivery is `<name>.jpg`, the stereo delivery `<name>_orig.png`. New stateless `resolve_image_path` / `image_path_or_default` (`gt/image_manager`) probe the common suffix/extension variants; all disk-lookup call sites routed through it.
- **Stereo Full/Left/Right toggle** is hidden unless the current frame is actually a side-by-side pair (no clutter on single-camera datasets).
- **Auto-stretch toggle** — optional 2–98 % percentile contrast stretch per frame via pyqtgraph display levels.

## Tests
+5 resolver unit tests — **188 passing**. `config/config.yaml` stays gitignored.